### PR TITLE
Summary: Initialize pseudo terminal window size

### DIFF
--- a/forth-interaction-mode.el
+++ b/forth-interaction-mode.el
@@ -51,6 +51,8 @@
     (unless (comint-check-proc buffer)
       (run-hooks 'run-forth-hooks)
       (make-comint-in-buffer "forth" buffer forth-executable)
+      (set-process-window-size (get-buffer-process buffer)
+			       (window-width) (window-height))
       (set-process-sentinel (get-buffer-process buffer)
 			    'forth-interaction-sentinel)
       (forth-interaction-mode)


### PR DESCRIPTION
SwiftForth (according to strace) reads the terminal window size and segfaults if it is 0.
With this change I can start it normally with `run-forth`.