### PR TITLE
Don't send output as input

### DIFF
--- a/forth-interaction-mode.el
+++ b/forth-interaction-mode.el
@@ -155,11 +155,9 @@
     (setq result (forth-scrub result t))
     (if (< (count ?\n result) 2)
 	(message "%s" result)
-      (let ((buffer (current-buffer)))
-	(pop-to-buffer forth-interaction-buffer)
-	(goto-char (point-max))
-	(insert result "\n")
-	(pop-to-buffer buffer)))))
+      (pop-to-buffer forth-interaction-buffer))
+    (comint-output-filter (get-buffer-process forth-interaction-buffer)
+			  (concat result "\n"))))
 
 ;;;###autoload
 (defun forth-see (word)


### PR DESCRIPTION
Use 'comint-output-filter instead of 'insert when inserting output.
If text is inserted with a normal 'insert the text is included as
as input the next time RET is pressed.