### PR TITLE
Don't kill the *forth* buffer

### DIFF
--- a/forth-interaction-mode.el
+++ b/forth-interaction-mode.el
@@ -59,7 +59,7 @@
 
 (defun forth-interaction-sentinel (proc arg)
   (message "Forth: %s" arg)
-  (forth-kill (process-buffer proc)))
+  (comint-output-filter proc (format "\nForth: %s\n" arg)))
 
 (defvar forth-executable nil)
 


### PR DESCRIPTION
`forth-interaction-sentinel` kills the `*forth*` buffer.  I think that's counter productive, especially when the subprocess just crashed. 
