### PR TITLE
Include tab (\t) as delimiter for comments.

### DIFF
--- a/forth-mode.el
+++ b/forth-mode.el
@@ -87,14 +87,16 @@
 		 (not (forth--ppss-in-comment-p (1- (point)))))
 	(cond ((save-excursion
 		 (goto-char (1- (point)))
-		 (not (looking-at "\\([ \n]\\|\\\`\\)\\((\\|\\\\\\)[ \n]")))
+		 (not (looking-at
+		       "\\([ \n\t]\\|\\\`\\)\\((\\|\\\\\\)[ \n\t]")))
 	       (put-text-property (point) (forth-symbol-end)
 				  'syntax-table (string-to-syntax "_")))
 	      ((and (looking-at "(")
 		    (re-search-forward ")" nil t))
-	       (put-text-property (point) (1+ (point))
+	       (put-text-property (1- (point)) (point)
 				  'syntax-table (string-to-syntax "!")))))
-      (forward-char))))
+      (unless (eobp)
+	(forward-char)))))
 
 (defun forth-expand-symbol ()
   (let ((list (forth-words)))

--- a/test/tests.el
+++ b/test/tests.el
@@ -15,3 +15,33 @@
   (should (eq major-mode 'forth-mode))
   (should (and (boundp 'forth-block-mode) forth-block-mode))
   (kill-buffer))
+
+(defmacro forth-with-temp-buffer (contents &rest body)
+  (declare (indent 1) (debug t))
+  `(with-temp-buffer
+     (insert ,contents)
+     (forth-mode)
+     ,@body))
+
+(defun forth-assert-face (content pos face)
+  (forth-with-temp-buffer content
+    (font-lock-fontify-buffer)
+    (should (eq face (get-text-property pos 'face)))))
+
+(ert-deftest forth-paren-comment-font-lock ()
+  (forth-assert-face "( )" 1 font-lock-comment-delimiter-face)
+  (forth-assert-face ".( )" 1 nil)
+  (forth-assert-face "( )" 3 font-lock-comment-delimiter-face)
+  (forth-assert-face " ( )" 2 font-lock-comment-delimiter-face)
+  (forth-assert-face "\t( )" 2 font-lock-comment-delimiter-face)
+  (forth-assert-face "(\t)" 1 font-lock-comment-delimiter-face)
+  (forth-assert-face "(foo) " 3 nil)
+  (forth-assert-face "( foo) " 3 font-lock-comment-face)
+  (forth-assert-face "( a b --
+                        x y )" 1 font-lock-comment-delimiter-face))
+
+(ert-deftest forth-backslash-comment-font-lock ()
+  (forth-assert-face "\\ " 1 font-lock-comment-delimiter-face)
+  (forth-assert-face " \\ " 2 font-lock-comment-delimiter-face)
+  (forth-assert-face "\t\\ " 2 font-lock-comment-delimiter-face)
+  (forth-assert-face "a\\b " 2 nil))


### PR DESCRIPTION
* test/tests.el (forth-backslash-comment-font-lock)
(forth-paren-comment-font-lock): New tests.
* forth-mode.el (forth--syntax-propertize): Handle the new test cases.