### PR TITLE
Add tests for word movement commands

### DIFF
--- a/test/tests.el
+++ b/test/tests.el
@@ -56,6 +56,12 @@ The whitespace before and including \"|\" on each line is removed."
     (forward-sexp)
     (should (= (point) end))))
 
+(defun forth-assert-forward-word (content start end)
+  (forth-with-temp-buffer content
+    (goto-char start)
+    (forward-word)
+    (should (= (point) end))))
+
 (ert-deftest forth-paren-comment-font-lock ()
   (forth-assert-face "( )" 1 font-lock-comment-delimiter-face)
   (forth-assert-face ".( )" 1 font-lock-comment-face)
@@ -181,3 +187,12 @@ The whitespace before and including \"|\" on each line is removed."
   (forth-assert-forward-sexp " : foo bar ; \ x" 2 13)
   (forth-assert-forward-sexp " :noname foo bar ; \ x" 2 19)
   (forth-assert-forward-sexp " if drop exit else 1+ then bar " 2 27))
+
+;; IDEA 1: in words like foo-bar give the "-" a "word constituent"
+;; syntax so that word movement works like in Lisp mode (which
+;; everybody is used to :-).
+;;
+;; IDEA 2: give the filename in "include filename" string syntax.
+(ert-deftest forth-word-movements ()
+  (forth-assert-forward-word "include /tmp/foo.fth \ bar" 1 8)
+  (forth-assert-forward-word "include /tmp/foo.fth \ bar" 8 21))


### PR DESCRIPTION
* test/tests.el (forth-word-movements): New test.
(forth-assert-forward-word): New helper.

* forth-syntax.el (forth-syntax--state-normal): Use "word constituent"
("w") instead of "symbol constituent" ("_"), so that word movements
works better.
(forth-syntax--set-syntax): New helper.