### PR TITLE
Add test for comment-dwim

### DIFF
--- a/forth-mode.el
+++ b/forth-mode.el
@@ -136,11 +136,10 @@
   (setq-local parse-sexp-lookup-properties t)
   (forth-smie-setup)
   (setq-local fill-paragraph-function #'forth-fill-paragraph)
-  (setq ;; font-lock-defaults
-	comment-start-skip "\\((\\*?\\|\\\\\\) *"
-	comment-start "("
-	comment-end ")"
-	imenu-generic-expression
+  (setq-local comment-start-skip "\\(?:(\\*\\|\\\\\\) *")
+  (setq-local comment-start "(")
+  (setq-local comment-end ")")
+  (setq imenu-generic-expression
 	'(("Words"
 	   "^\\s-*\\(:\\|code\\|defer\\)\\s-+\\(\\(\\sw\\|\\s_\\)+\\)" 2)
 	  ("Variables"

--- a/test/tests.el
+++ b/test/tests.el
@@ -89,12 +89,12 @@ The whitespace before and including \"|\" on each line is removed."
 	(should (= (point) point-after))))))
 
 (ert-deftest forth-paren-comment-font-lock ()
-  (forth-assert-face "→( )" font-lock-comment-delimiter-face)
+  (forth-assert-face "→( )" font-lock-comment-face)
   (forth-assert-face "→.( )" font-lock-comment-face)
   (forth-assert-face "( →)" font-lock-comment-delimiter-face)
-  (forth-assert-face " →( )" font-lock-comment-delimiter-face)
-  (forth-assert-face "\t→( )" font-lock-comment-delimiter-face)
-  (forth-assert-face "→(\t)" font-lock-comment-delimiter-face)
+  (forth-assert-face " →( )" font-lock-comment-face)
+  (forth-assert-face "\t→( )" font-lock-comment-face)
+  (forth-assert-face "→(\t)" font-lock-comment-face)
   (forth-assert-face "(fo→o) " nil)
   (forth-assert-face "(fo→o)" nil)
   (forth-assert-face "(→) " nil)
@@ -257,3 +257,17 @@ The whitespace before and including \"|\" on each line is removed."
    "\\ foo bar baz→
    |: frob ( x y -- z ) ;"
    #'fill-paragraph))
+
+;; FIXME: maybe insert "(  )" instead of "()".
+(ert-deftest forth-comment-dwim ()
+  (forth-should-before/after
+   ": frob
+   |  begin     ( x y )
+   |    swap→
+   |  again ;"
+   ": frob
+   |  begin     ( x y )
+   |    swap    (→)
+   |  again ;"
+   (lambda ()
+     (call-interactively #'comment-dwim))))


### PR DESCRIPTION
That's the command run by M-;.
Not sure what we actually want it to do but the test case is not
entirely unreasonable.

* test/tests.el (forth-comment-dwim): New test.
(forth-paren-comment-font-lock): Changing some of the comment-* variables
also changed the some of font-lock-comment-delimiter-face into
font-lock-comment-face.  Odd.

* forth-mode.el (forth-mode): Use a shy group in the
comment-start-skip regexp, as the non-shy group has some special
meaning (I couldn't quite decipher the docstring) and the test case
seems to work fine with shy groups.
Also, use setq-local as the comment-* variables are not permanently local.