### PR TITLE
Test completion-at-point

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 install:
   - sudo add-apt-repository -y ppa:ubuntu-elisp
   - sudo apt-get update -y
-  - sudo apt-get install emacs23 emacs24 emacs-snapshot
+  - sudo apt-get install emacs23 emacs24 emacs-snapshot pforth
 script: make EMACS=$EMACS
 notifications:
   email: lars@nocrew.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 install:
   - sudo add-apt-repository -y ppa:ubuntu-elisp
   - sudo apt-get update -y
-  - sudo apt-get install emacs23 emacs24 emacs-snapshot pforth
+  - sudo apt-get install emacs23 emacs24 emacs-snapshot gforth
 script: make EMACS=$EMACS
 notifications:
   email: lars@nocrew.org

--- a/forth-interaction-mode.el
+++ b/forth-interaction-mode.el
@@ -59,7 +59,11 @@
 
 (defun forth-interaction-sentinel (proc arg)
   (message "Forth: %s" arg)
-  (comint-output-filter proc (format "\nForth: %s\n" arg)))
+  ;;FIXME: Can't do this because it calls process-mark, which
+  ;; errors out in killed processes.  Still, would be nice to see
+  ;; something in the *forth* buffer.
+  ;;(comint-output-filter proc (format "\nForth: %s\n" arg))
+  )
 
 (defvar forth-executable nil)
 

--- a/forth-mode.el
+++ b/forth-mode.el
@@ -65,13 +65,13 @@
 
 (defun forth-symbol-start ()
   (save-excursion
-    (re-search-backward "[^[:graph:]]")
-    (1+ (point))))
+    (skip-chars-backward forth-syntax-non-whitespace)
+    (point)))
 
 (defun forth-symbol-end ()
   (save-excursion
-    (re-search-forward "[^[:graph:]]")
-    (1- (point))))
+    (skip-chars-forward forth-syntax-non-whitespace)
+    (point)))
 
 (defun forth-word-at-point ()
   (buffer-substring (forth-symbol-start) (forth-symbol-end)))

--- a/forth-syntax.el
+++ b/forth-syntax.el
@@ -8,15 +8,15 @@
 
 ;;; Helpers
 
-(defvar forth-syntax--whitespace " \t\n\f\r")
-(defvar forth-syntax--non-whitespace (concat "^" forth-syntax--whitespace))
+(defvar forth-syntax-whitespace " \t\n\f\r")
+(defvar forth-syntax-non-whitespace (concat "^" forth-syntax-whitespace))
 
 ;; Skip forward over whitespace and the following word. Return the
 ;; start position of the word.
 (defun forth-syntax--skip-word ()
-  (skip-chars-forward forth-syntax--whitespace)
+  (skip-chars-forward forth-syntax-whitespace)
   (let ((start (point)))
-    (skip-chars-forward forth-syntax--non-whitespace)
+    (skip-chars-forward forth-syntax-non-whitespace)
     start))
 
 ;; Return the whitespace-delimited word at position POS.

--- a/test/tests.el
+++ b/test/tests.el
@@ -88,15 +88,15 @@ The whitespace before and including \"|\" on each line is removed."
 	(should (string= after (substring-no-properties (buffer-string))))
 	(should (= (point) point-after))))))
 
-(defmacro forth-with-pforth (&rest body)
+(defmacro forth-with-gforth (&rest body)
   (declare (indent 0))
-  `(let* ((forth-executable "pforth")
+  `(let* ((forth-executable "gforth")
 	  (proc (get-buffer-process forth-interaction-buffer)))
      ;; FIXME: there should be a better way to do this. Probably a
      ;; callback function.
      (while (not (processp proc))
        (run-forth)
-       (message "Waiting for pforth to start ...")
+       (message "Waiting for gforth to start ...")
        (accept-process-output nil 0.3)
        (setq proc (get-buffer-process forth-interaction-buffer)))
      (unwind-protect
@@ -288,8 +288,8 @@ The whitespace before and including \"|\" on each line is removed."
      (call-interactively #'comment-dwim))))
 
 (ert-deftest forth-completion-at-point ()
-  (forth-with-pforth
+  (forth-with-gforth
     (forth-should-before/after
-     "CREATE-F→"
-     "CREATE-FILE→"
+     "2C→"
+     "2Constant→"
      #'completion-at-point)))


### PR DESCRIPTION
.travis.yml: Install pforth   Using pForth as that is less likely
to create conflicts with gforth.el.

* test/tests.el (forth-completion-at-point): New test.
(forth-with-pforth): New helper.

* forth-mode.el (forth-symbol-start, forth-symbol-end): Don't break
at beginning/end of buffer.

(forth-interaction-sentinel): Can't use comint-output-filter with
killed processes.

* forth-syntax.el (forth-syntax-whitespace): Renamed from
  forth-syntax--whitespace
(forth-syntax-non-whitespace): Idem.