### PR TITLE
Test comment-region

### DIFF
--- a/forth-mode.el
+++ b/forth-mode.el
@@ -40,9 +40,9 @@
 (defvar forth-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?\\ "<" table)
-    (modify-syntax-entry ?\n " " table)
-    (modify-syntax-entry ?\( "!" table)
-    (modify-syntax-entry ?\) "_" table)
+    (modify-syntax-entry ?\n ">" table)
+    (modify-syntax-entry ?\( "<1b" table)
+    (modify-syntax-entry ?\) ">4b" table)
     (modify-syntax-entry ?* "_23n" table)
     (modify-syntax-entry ?\{ "_" table)
     (modify-syntax-entry ?\} "_" table)
@@ -112,9 +112,14 @@
 (defun forth-fill-paragraph (&rest args)
   (let ((fill-paragraph-function nil)
 	(fill-paragraph-handle-comment t)
-	(comment-start "\ ")
+	(comment-start "\\ ")
 	(comment-end ""))
     (apply #'fill-paragraph args)))
+
+(defun forth-comment-region (&rest args)
+  (let ((comment-start "\\ ")
+	(comment-end ""))
+    (apply #'comment-region-default args)))
 
 (defun forth-beginning-of-defun (arg)
   (and (re-search-backward "^\\s *: \\_<" nil t (or arg 1))
@@ -141,9 +146,10 @@
   (forth-smie-setup)
   (setq-local fill-paragraph-function #'forth-fill-paragraph)
   (setq-local beginning-of-defun-function #'forth-beginning-of-defun)
-  (setq-local comment-start-skip "\\(?:(\\*\\|\\\\\\) *")
+  (setq-local comment-start-skip "\\(?:([*]?\\|\\\\\\) *")
   (setq-local comment-start "(")
   (setq-local comment-end ")")
+  (setq-local comment-region-function #'forth-comment-region)
   (setq imenu-generic-expression
 	'(("Words"
 	   "^\\s-*\\(:\\|code\\|defer\\)\\s-+\\(\\(\\sw\\|\\s_\\)+\\)" 2)

--- a/forth-syntax.el
+++ b/forth-syntax.el
@@ -139,10 +139,10 @@ SYNTAX must be a valid argument for `string-to-syntax'."
 (defun forth-syntax--parse-comment (backward-regexp forward-regexp)
   (let ((pos (point)))
     (re-search-backward backward-regexp)
-    (forth-syntax--set-syntax (point) (1+ (point)) "<")
+    (forth-syntax--set-syntax (point) (1+ (point)) "!")
     (goto-char pos)
     (cond ((re-search-forward forward-regexp nil t)
-	   (forth-syntax--set-syntax (1- (point)) (point) ">")
+	   (forth-syntax--set-syntax (1- (point)) (point) "!")
 	   #'forth-syntax--state-normal)
 	  (t
 	   (goto-char (point-max))


### PR DESCRIPTION
* forth-mode.el (forth-comment-region): New. Use \ for commenting
regions.  ( also worked, but it seems nicer to \ for "block comments"
and ( ) for stack comments.
(forth-mode-syntax-table): Change syntax table again so that comments
work a bit better in Emacs23.
(forth-mode): Setup comment-region-function.
Also fix comment-start-skip.  (Allthough it's not clear why
we need to set this at all.)

* test/tests.el (forth-comment-dwim): Add tests with active region.
(forth-should-region-before/after): New helper.
(forth-paren-comment-font-lock): Fixing comment-start-skip changed
the faces back again.

* forth-syntax.el (forth-syntax--parse-comment): Use "!" (i.e. generic
comment) here so that the syntax table can use "<" and ">".