### PR TITLE
Try to indent (foo)

### DIFF
--- a/forth-mode.el
+++ b/forth-mode.el
@@ -146,9 +146,9 @@
   (forth-smie-setup)
   (setq-local fill-paragraph-function #'forth-fill-paragraph)
   (setq-local beginning-of-defun-function #'forth-beginning-of-defun)
-  (setq-local comment-start-skip "\\(?:([*]?\\|\\\\\\) *")
-  (setq-local comment-start "(")
-  (setq-local comment-end ")")
+  (setq-local comment-start-skip "[(\\][ \t*]+")
+  (setq-local comment-start "( ")
+  (setq-local comment-end " )")
   (setq-local comment-region-function #'forth-comment-region)
   (setq imenu-generic-expression
 	'(("Words"

--- a/forth-smie.el
+++ b/forth-smie.el
@@ -32,7 +32,8 @@
   (pcase (cons kind token)
     (`(:elem . basic) forth-smie--basic-indent)
     (`(:elem . args) 0)
-    (`(:list-intro . ,_) forth-smie--basic-indent)))
+    (`(:list-intro . ,_) forth-smie--basic-indent)
+    (_ nil)))
 
 (defun forth-smie--forward-token ()
   (forward-comment (point-max))

--- a/test/tests.el
+++ b/test/tests.el
@@ -114,12 +114,12 @@ The whitespace before and including \"|\" on each line is removed."
                         →x y )" font-lock-comment-face))
 
 (ert-deftest forth-backslash-comment-font-lock ()
-  (forth-assert-face "→\\" font-lock-comment-delimiter-face)
+  (forth-assert-face "→\\" font-lock-comment-face)
   (forth-assert-face "→\\ " font-lock-comment-delimiter-face)
-  (forth-assert-face " →\\" font-lock-comment-delimiter-face)
+  (forth-assert-face " →\\" font-lock-comment-face)
   (forth-assert-face "\t→\\ " font-lock-comment-delimiter-face)
   (forth-assert-face " →\\\t" font-lock-comment-delimiter-face)
-  (forth-assert-face " →\\\n" font-lock-comment-delimiter-face)
+  (forth-assert-face " →\\\n" font-lock-comment-face)
   (forth-assert-face "a→\\b" nil)
   (forth-assert-face "a→\\b " nil))
 
@@ -242,6 +242,15 @@ The whitespace before and including \"|\" on each line is removed."
    |  drop exit
    |endcase"))
 
+;; This is an tricky case because SMIE thinks, depending on
+;; `comment-start-skip` (which indirectly depends on `comment-start`
+;; thru `comment-normalize-vars`), that (foo) is a comment.  But since
+;; (foo) is not actually a comment this leads to an endless recursion.
+(ert-deftest forth-indent-\(foo\) ()
+  (forth-should-indent
+   ": foo
+   |  (foo) ;"))
+
 (ert-deftest forth-sexp-movements ()
   (forth-assert-forward-sexp " ¹: foo bar ;² \ x")
   (forth-assert-forward-sexp " ¹:noname foo bar ;² \ x")
@@ -288,7 +297,7 @@ The whitespace before and including \"|\" on each line is removed."
    |  again ;"
    ": frob
    |  begin     ( x y )
-   |    swap    (→)
+   |    swap    ( → )
    |  again ;"
    (lambda ()
      (call-interactively #'comment-dwim)))


### PR DESCRIPTION
This is a tricky case because SMIE thinks, depending on
`comment-start-skip` (which indirectly depends on `comment-start`
thru `comment-normalize-vars`), that (foo) is a comment.  But since
(foo) is not actually a comment this leads to an endless recursion.

* forth-mode.el (comment-start-skip, comment-start): Choose them
so that SMIE doesn't run into the endless recursion. (Quite brittle.)

* test/tests.el (forth-indent-\(foo\)): New test.
(forth-backslash-comment-font-lock, forth-comment-dwim): Adjust for
new values of comment-start-skip.

* forth-smiel.el (forth-smie--indentation-rules): For clarity, make
default case explicit.