### PR TITLE
Declare forth-smie-basic-indent as safe local-variable.

### DIFF
--- a/forth-smie.el
+++ b/forth-smie.el
@@ -5,7 +5,8 @@
 (defcustom forth-smie-basic-indent 2
   "Basic amount of indentation."
   :type 'integer
-  :group 'forth-smie)
+  :group 'forth-smie
+  :safe 'integerp)
 
 (defvar forth-smie--grammar
   (smie-prec2->grammar


### PR DESCRIPTION
Make forth-smie-basic-indent usable in .dir-locals.el.