### PR TITLE
Check if forth interactive buffer is alive

### DIFF
--- a/forth-interaction-mode.el
+++ b/forth-interaction-mode.el
@@ -99,7 +99,7 @@
   (run-forth))
 
 (defun forth-ensure ()
-  (unless forth-interaction-buffer
+  (unless (buffer-live-p forth-interaction-buffer)
     (run-forth))
   (get-buffer-process forth-interaction-buffer))
 


### PR DESCRIPTION
When the buffer is killed the variable `forth-interaction-buffer` references to
a killed buffer i.e `#<killed buffer>`.