### PR TITLE
Add support for .forth file extension

### DIFF
--- a/forth-mode.el
+++ b/forth-mode.el
@@ -221,6 +221,7 @@
     (speedbar-add-supported-extension ".f")
     (speedbar-add-supported-extension ".fs")
     (speedbar-add-supported-extension ".fth")
+    (speedbar-add-supported-extension ".forth")
     (speedbar-add-supported-extension ".4th")))
 
 (defun forth-beginning ()


### PR DESCRIPTION
I was working with a Forth program that uses `.forth` as a file extension for its forth files. This adds such support to this package. 