### PR TITLE
Add a target 'check' to the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EMACS = emacs
 EMACS_LOAD = $(EMACS) -Q --batch --load
-FORTH = gforth
+FORTH = gforth-0.7.3
 
 SRC = $(wildcard *.el) $(wildcard backend/*.el)
 
@@ -13,6 +13,10 @@ doc: forth-mode.info
 
 %.info: %.texi
 	makeinfo $<
+
+check: forth-mode.elc
+	FORTH=$(FORTH) $(EMACS) -Q --batch -L . -l test/tests.el \
+	-f ert-run-tests-batch-and-exit
 
 clean:
 	rm -f autoloads.el *.elc backend/*.elc

--- a/test/tests.el
+++ b/test/tests.el
@@ -1,3 +1,10 @@
+(require 'forth-mode)
+(require 'forth-interaction-mode)
+(require 'forth-block-mode)
+
+(unless forth-executable
+  (setq forth-executable (getenv "FORTH")))
+
 (ert-deftest load-not-block ()
   (find-file "test/noblock.fth")
   (should (eq major-mode 'forth-mode))


### PR DESCRIPTION
The new 'make check' runs the tests without forcing a recompile.

I also changed gforth to gforth-0.7.3, because the current snapshot version doesn't pass the tests.
I'm not sure how I can trigger the CI server to see if this acutally works.