### PR TITLE
Customizable indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EMACS = emacs
 EMACS_LOAD = $(EMACS) -Q --batch --load
-FORTH = gforth
+FORTH = gforth-0.7.3
 
 SRC = $(wildcard *.el) $(wildcard backend/*.el)
 
@@ -13,6 +13,10 @@ doc: forth-mode.info
 
 %.info: %.texi
 	makeinfo $<
+
+check: forth-mode.elc
+	FORTH=$(FORTH) $(EMACS) -Q --batch -L . -l test/tests.el \
+	-f ert-run-tests-batch-and-exit
 
 clean:
 	rm -f autoloads.el *.elc backend/*.elc

--- a/forth-mode.el
+++ b/forth-mode.el
@@ -193,6 +193,7 @@
   (when (boundp 'syntax-propertize-function)
     (setq-local syntax-propertize-function #'forth-syntax-propertize))
   (setq-local parse-sexp-lookup-properties t)
+  (hack-local-variables)
   (forth-smie-setup)
   (setq-local fill-paragraph-function #'forth-fill-paragraph)
   (setq-local beginning-of-defun-function #'forth-beginning-of-defun)

--- a/test/tests.el
+++ b/test/tests.el
@@ -52,7 +52,7 @@
 
 (defun forth-assert-face (content face)
   (when (boundp 'syntax-propertize-function)
-    (destructuring-bind (content pos) (forth-strip-|-and-→ content)
+    (cl-destructuring-bind (content pos) (forth-strip-|-and-→ content)
       (forth-with-temp-buffer content
 	(font-lock-ensure)
 	(should (eq face (or (get-text-property pos 'face)
@@ -72,14 +72,14 @@ The whitespace before and including \"|\" on each line is removed."
 			 (substring-no-properties (buffer-string))))))))
 
 (defun forth-assert-forward-sexp (content)
-  (destructuring-bind (content start end) (forth-strip-|-and-¹² content)
+  (cl-destructuring-bind (content start end) (forth-strip-|-and-¹² content)
     (forth-with-temp-buffer content
       (goto-char start)
       (forward-sexp)
       (should (= (point) end)))))
 
 (defun forth-assert-forward-word (content)
-  (destructuring-bind (content start end) (forth-strip-|-and-¹² content)
+  (cl-destructuring-bind (content start end) (forth-strip-|-and-¹² content)
     (forth-with-temp-buffer content
       (goto-char start)
       (font-lock-ensure) ; Make sure syntax-propertize function is called
@@ -87,8 +87,8 @@ The whitespace before and including \"|\" on each line is removed."
       (should (= (point) end)))))
 
 (defun forth-should-before/after (before after fun)
-  (destructuring-bind (before point-before) (forth-strip-|-and-→ before)
-    (destructuring-bind (after point-after) (forth-strip-|-and-→ after)
+  (cl-destructuring-bind (before point-before) (forth-strip-|-and-→ before)
+    (cl-destructuring-bind (after point-after) (forth-strip-|-and-→ after)
       (forth-with-temp-buffer before
 	(goto-char point-before)
 	(funcall fun)
@@ -96,8 +96,8 @@ The whitespace before and including \"|\" on each line is removed."
 	(should (= (point) point-after))))))
 
 (defun forth-should-region-before/after (before after fun)
-  (destructuring-bind (before start1 end1) (forth-strip-|-and-¹² before)
-    (destructuring-bind (after point-after) (forth-strip-|-and-→ after)
+  (cl-destructuring-bind (before start1 end1) (forth-strip-|-and-¹² before)
+    (cl-destructuring-bind (after point-after) (forth-strip-|-and-→ after)
       (forth-with-temp-buffer before
 	(set-mark start1)
 	(goto-char end1)
@@ -267,10 +267,20 @@ The whitespace before and including \"|\" on each line is removed."
    |  [char] b of bar
    |              baz
    |           endof
-   |  test ?of bar
-   |           baz
-   |       endof
+   |  test ?of
    |  drop exit
+   |endcase"))
+
+(ert-deftest forth-indent-customization ()
+  (forth-should-indent
+   "\ -*- forth-smie-bnf-extensions: ((ext (\"?of\" words \"endof\"))) -*-
+   |x case
+   |  [char] f of
+   |    foo
+   |  endof
+   |  test ?of
+   |    bar
+   |  endof
    |endcase"))
 
 ;; This is an tricky case because SMIE thinks, depending on

--- a/test/tests.el
+++ b/test/tests.el
@@ -1,3 +1,10 @@
+(require 'forth-mode)
+(require 'forth-interaction-mode)
+(require 'forth-block-mode)
+
+(unless forth-executable
+  (setq forth-executable (getenv "FORTH")))
+
 (ert-deftest load-not-block ()
   (find-file "test/noblock.fth")
   (should (eq major-mode 'forth-mode))


### PR DESCRIPTION
This makes the indentation rules "officially" customizable.
The idea is that users set the new variable forth-smie-bnf-extensions to whatever custom syntax they have in their project.  Most likely in .dir-local.el.