### PR TITLE
Add a basic .elpaignore file

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,0 +1,6 @@
+autoloads.el
+build.el
+forth-mode-autoloads.el
+forth-mode-pkg.el
+Makefile
+.travis.yml


### PR DESCRIPTION
NonGNU ELPA has an outdated list of files to not include in the release tarball, so I'd suggest to track this information inside the repository instead.