### PR TITLE
Save buffers before loading file

### DIFF
--- a/forth-interaction-mode.el
+++ b/forth-interaction-mode.el
@@ -163,6 +163,7 @@
 ;;;###autoload
 (defun forth-load-file (file)
   (interactive (list (buffer-file-name (current-buffer))))
+  (save-some-buffers)
   (let ((result (forth-interaction-send-raw-result (format "s\" %s\" included" file))))
     (setq result (forth-scrub result t))
     (if (< (cl-count ?\n result) 2)


### PR DESCRIPTION
This is a convenient hint, to avoid loading outdated files.  Perhaps one could add a user option to automatically save files or never query the user?