### PR TITLE
Fix forth-spec for Forth 2012 using https://forth-standard.org

### DIFF
--- a/forth-spec.el
+++ b/forth-spec.el
@@ -31,7 +31,7 @@
   "Browsing Forth standards."
   :group 'forth)
 
-(defcustom forth-spec-url-2012 "http://www.forth200x.org/documents/html/"
+(defcustom forth-spec-url-2012 "https://forth-standard.org/standard/"
   "The URL which contains the HTML version of the standard.
 If you have a local copy set this variable to
 something like \"file://home/joe/docs/ANS-Forth/\".
@@ -123,9 +123,8 @@ Note: the string should have a trailing backslash."
 (defun forth-spec--parse-2012 ()
   (let ((index '())
 	(case-fold-search nil)
-	(rx "<td>\
-<a href=\"\\([^\"]+\\)\">\\([^<]+\\)</a>\
-</td><td>\\(?:\"\\([^\"]+\\)\"\\)?</td>"))
+	(rx "</td><td><a href=\"\\([^\"]+\\)\">\
+\\([^<]+\\)</a></td><td>\\(?:\"\\(\"+\\)\"\\)??</td>"))
     (search-forward "<table")
     (while (re-search-forward rx nil t)
       (push (list (forth-spec--decode-entities (match-string 2))


### PR DESCRIPTION
http://www.forth200x.org links to https://forth-standard.org for a HTML version of the specification, so a change like this is necessary.