### PR TITLE
Better tests for forth-spec.el

### DIFF
--- a/forth-spec.el
+++ b/forth-spec.el
@@ -137,7 +137,8 @@ Note: the string should have a trailing backslash."
   (let ((index '())
 	(case-fold-search nil)
 	(rx "</td><td><a href=\"\\([^\"]+\\)\">\
-\\([^<]+\\)</a></td><td>\"\\([^\"]+\\)\"</td><td[^<]*>[^<]*</td></tr>"))
+\\([^<]+\\)</a></td><td>\\(:?\"\\([^\"]+\\)\"\\)?</td>\
+<td[^<]*>[^<]*</td></tr>"))
     (search-forward "<table")
     (while (re-search-forward rx nil t)
       (push (list (forth-spec--decode-entities (match-string 2))

--- a/test/tests.el
+++ b/test/tests.el
@@ -371,7 +371,11 @@ The whitespace before and including \"|\" on each line is removed."
   (should (equal (forth-spec--build-url "SWAP" 1994)
 		 "http://lars.nocrew.org/dpans/dpans6.htm#6.1.2260"))
   (should (string-match "core/ColonNONAME"
-			(forth-spec--build-url ":NONAME" 2012))))
+			(forth-spec--build-url ":NONAME" 2012)))
+  (should (string-match "memory/ALLOCATE"
+			(forth-spec--build-url "ALLOCATE" 2012)))
+  (should (= (length (cdr (assoc 2012 forth-spec--index-cache)))
+	     450)))
 
 (ert-deftest forth-fill-comment ()
   (forth-should-before/after


### PR DESCRIPTION
The last patch failed to match a different set of words.  This should now match all of them.