### PR TITLE
Experimental branch to replace comint-mode with term-mode

### DIFF
--- a/backend/gforth.el
+++ b/backend/gforth.el
@@ -1,3 +1,5 @@
+;;                                               -*- lexical-binding:t -*-
+
 (require 'forth-interaction-mode)
 
 (defun forth-gforth-init (backend-type process)
@@ -5,5 +7,28 @@
     (forth-interaction-send "' drop is Attr!")))
 
 (add-hook 'forth-interaction-init-backend-hook #'forth-gforth-init)
+
+
+;; Setup code forth-term.el
+
+(defun forth-gforth--init-term-file ()
+  (file-name-concat forth-backend-dir "gforth.fth"))
+
+(defun forth-gforth--init-term-2 (proc)
+  (let ((str (format "s\" %s\" included\n" (forth-gforth--init-term-file))))
+    (term-send-string proc str))
+  (let* ((ack nil)
+	 (term-command-function
+	  (lambda (str)
+	    (message "%s" str)
+	    (setq ack t))))
+    (while (not ack)
+      (accept-process-output proc 1))))
+
+(defun forth-gforth--init-term (impl proc)
+  (when (eq impl 'gforth)
+    (forth-gforth--init-term-2 proc)))
+
+(add-hook 'forth-term-init-backend-hook #'forth-gforth--init-term)
 
 (provide 'gforth)

--- a/backend/gforth.fth
+++ b/backend/gforth.fth
@@ -1,0 +1,144 @@
+\ gforth.fth -- Setup terminal IO for forth-term.el
+
+wordlist constant eterm-wordlist
+forth-wordlist eterm-wordlist 2 set-order
+
+26 constant 'C-z'  \ 26 == \032 == Ctrl-z
+10 constant '\n'
+
+\ Append the string C-ADDR U to the current command
+: cmd, ( c-addr u -- )
+  0 ?do
+    dup c@ case
+      '\n' of '\' c, 'n' c, endof
+      '\'  of '\' c, '\' c, endof
+      dup c,
+    endcase
+    char+
+  loop
+  drop
+;
+
+\ Execute XT (which should use CMD, to build the command) and finally
+\ send the command as an escape sequence to Emacs.
+\
+\ The sequences should match the regexp: "\032[^\n]+\n"
+: send-emacs-cmd ( xt -- )
+  here >r
+  'C-z' c,
+  execute
+  '\n' c,
+  r> here over - 2dup type
+  nip negate allot
+;
+
+\ Enable the status line at the bottom of the window.  This tests our
+\ cursor positioning code.
+[defined] +status [if] +status [then]
+
+: %ping ( c-addr u -- ) s" pong " cmd, cmd, ;
+
+\ Wordlist for commands that we support
+wordlist constant eterm-cmds-wordlist
+eterm-cmds-wordlist set-current
+
+\ Simply send C-ADDR U back to Emacs
+: ping ( c-addr u -- ) ['] %ping send-emacs-cmd ;
+
+eterm-wordlist set-current
+
+: split-string ( addr u char – addr u1 addr2 u2 )
+  >r 2dup      ( addr u addr u  )  ( r: char )
+  begin
+    dup 0<> if over c@ r@ <> else false then while
+    1 /string
+  repeat			( addr u addr2 u2 )  ( r: char )
+  r> drop
+  dup >r
+  2swap r> -
+  2swap
+;
+
+: execute-eterm-command ( c-addr u -- )
+  bl split-string
+  2swap eterm-cmds-wordlist search-wordlist
+  0= abort" invalid eterm command"
+  execute
+;
+
+\ Apparently they introduced IP-VECTOR after Gforth-0.7.3
+[defined] ip-vector [if]
+
+: with-input-vector ( xt vector -- )
+  ip-vector @ >r
+  ip-vector !
+  catch
+  r> ip-vector !
+  throw
+;
+
+: default-key-ior ( -- char|ior ) ['] key-ior default-in with-input-vector ;
+: default-key? ( -- flag ) ['] key? default-in with-input-vector ;
+
+[else]
+
+action-of key constant default-key-xt
+: default-key-ior ( -- char|ior ) default-key-xt execute ;
+: default-key? ( -- flag ) true abort" not yet implemented" ;
+
+: input: ( key-ior-xt key?-xt "name" -- )
+  drop create ,
+  does> @ dup is key is xkey
+;
+
+[then]
+
+: parse-eterm-command ( -- c-addr len )
+  here		      ( c-addr' )
+  begin
+    default-key-ior
+    dup 255 u> if throw then \ FIXME: do something more civilized
+    dup '\n' <> while
+    c,
+  repeat
+  drop
+  here over - save-mem
+  dup negate allot
+;
+
+\ Filter out commands sent from Emacs
+: eterm-key-ior ( -- char|ior )
+  begin
+    default-key-ior
+    dup 'C-z' = while
+    drop
+    parse-eterm-command
+    2dup execute-eterm-command
+    drop free throw
+  repeat
+;
+
+' eterm-key-ior ' default-key? input: eterm-input-vector
+
+: say-hello ( -- )
+  s" Welcome to Gforth " cmd, version-string cmd, s" !" cmd,
+;
+
+\ Normally Gforth configures the terminal so that pressing C-z
+\ generates a SIGTSTP signal.  (Gforth seems to ignore SIGTSTP.)  We
+\ disable VSUSP so that C-z can be read by KEY.
+: prepare-terminal ( -- )
+  s" stty susp undef" system
+  eterm-input-vector
+;
+
+: setup ( -- )
+  ['] say-hello send-emacs-cmd
+  prepare-terminal
+  expand-where  \ WHERE must print full filenames, even if it's ugly
+  2 to after-locate \ reduce clutter in the *forth-term* buffer a bit
+;
+
+setup
+
+only forth

--- a/forth-mode.el
+++ b/forth-mode.el
@@ -29,6 +29,7 @@
     (define-key map (kbd "C-c C-e")   'forth-eval-last-expression)
     (define-key map (kbd "C-x M-e")   'forth-eval-last-expression-display-output)
     (define-key map (kbd "C-c C-z")   'forth-switch-to-output-buffer)
+    (define-key map (kbd "C-c C-t")   'forth-term)
     (define-key map (kbd "C-c :")     'forth-eval)
     (define-key map (kbd "C-c C-d 1") 'forth-spec-lookup-1994)
     (define-key map (kbd "C-c C-d 2") 'forth-spec-lookup-2012)

--- a/forth-term.el
+++ b/forth-term.el
@@ -1,0 +1,156 @@
+;; forth-term.el --- Forth process in a buffer   -*- lexical-binding:t -*-
+
+;; This is an experiment to base our process-in-a-buffer mode on
+;; term-mode instead of comint-mode.  Most Forth systems switch the
+;; terminal to non-canonical mode (also called "raw mode") and assume
+;; that they can send ANSI escape sequences to position the cursor and
+;; the like.  There are also standard words like KEY and AT-XY that
+;; make much more sense if the terminal supports raw mode and
+;; interprets at least some ANSI escape sequences.
+;;
+;; Usually, comint-mode doesn't interpret escape sequences and usually
+;; doesn't support cursor positioning. (Though there seems to be some
+;; support to ansi-color and ansi-osc.)  This means that comint-mode
+;; will unlikely be a good Forth terminal.
+;;
+;; In contrast, term-mode supports cursor positioning and with
+;; term-char-mode we can support "raw" input reasonably well.  There's
+;; even support for an Emacs specific escape sequence "<command>\n"
+;; that can be used to send commands to Emacs.  (Bash and gdb seem to
+;; use this.)
+;;
+;; Unfortunately, term-mode has it's own set of problems.  E.g. it
+;; seems to endlessly fight with Emacs to force redisplay to do
+;; something that it doesn't do naturally; term-emulate-terminal calls
+;; redisplay for every piece of input it receives.  term.el also
+;; installs pre- and post-command-hooks in a vain attempt to keep
+;; window-point at the bottom of the window; but it's obvious after
+;; light testing that this doesn't work reliably.
+;;
+;; Also, the "" escape sequence sounds like a useful feature, but
+;; again, it's not reliable.  If the <command> part is too long,
+;; (probably when it is sent as two chunks) Emacs doesn't recognize
+;; the sequence and simply inserts it as text.
+;;
+;; Given all the limitations, this code tries to be very "low tech"
+;; and only provides very modest features.  In a first step, we mostly
+;; try to support Gforth: parse error messages and crude wrappers
+;; around Gforth's EDIT, BROWSE and WHERE commands.  (Those commands
+;; actually invoke emacsclient as the "return channel".)
+
+(require 'term)
+(require 'cl-lib)
+(require 'forth-interaction-mode) ; for forth-implementation-matches
+
+(defvar forth-term--buffer-name "*forth-term*")
+(defvar forth-term--command nil)
+
+(defun forth-term--buffer (&optional create)
+  (funcall (if create #'get-buffer-create #'get-buffer)
+	   forth-term--buffer-name))
+
+(defun forth-term--process ()
+  (let* ((buf (forth-term--buffer))
+	 (proc (and buf (get-buffer-process buf))))
+    (cl-assert proc)
+    proc))
+
+(defun forth-term--command-function (string)
+  (cond ((string-match "^pong \\(.*\\)$" string)
+	 (message "PONG: %s" (match-string 1 string)))
+	(t
+	 (error "Unsupported eterm command: %S" string))))
+
+(defun forth-term--init-backend ()
+  (let* ((proc (get-buffer-process (current-buffer))))
+    ;; Wait until we receive at least one line of output
+    (while (< (car (buffer-line-statistics)) 1)
+      (accept-process-output proc 1))
+    (let* ((banner (buffer-string))
+	   (probe (cl-assoc-if (lambda (pattern)
+				 (string-match pattern banner))
+			       forth-implementation-matches)))
+      (cond (probe
+	     (let ((impl (cdr probe)))
+	       (setq-local forth-implementation impl)
+	       (let ((load-path (cons forth-backend-dir load-path)))
+		 (require impl))
+	       (run-hook-with-args 'forth-term-init-backend-hook impl proc)))
+	    (t
+	     (display-warning
+	      'forth-term
+	      (format "Unknown Forth implementation\nBanner: %S" banner)))))))
+
+(defun forth-term--start-process (buffer)
+  (with-current-buffer buffer
+    (let* ((cmd (read-shell-command "Forth program: "
+				    (car shell-command-history)))
+	   (args (split-string-shell-command cmd))
+	   (_ (progn
+		(let ((inhibit-read-only t))
+		  (erase-buffer))
+		(term-mode)))
+	   (procname (buffer-name buffer))
+	   (buf (term-exec buffer procname (car args) nil (cdr args)))
+	   (proc (get-buffer-process buf)))
+      (forth-term--init-backend)
+      (setq-local term-command-function #'forth-term--command-function)
+      (term-char-mode)
+      proc)))
+
+(defun forth-term ()
+  "Start an interactive forth session."
+  (interactive)
+  (let* ((buffer (forth-term--buffer t)))
+    (when (not (term-check-proc buffer))
+      (forth-term--start-process buffer))
+    (pop-to-buffer-same-window buffer)))
+
+(defun forth-term--prepare-next-error-function ()
+  (with-current-buffer (forth-term--buffer)
+    (setq next-error-last-buffer (current-buffer))
+    (setq next-error-function #'compilation-next-error-function)
+    (setq-local compilation-locs
+		(make-hash-table :test 'equal :weakness 'value))
+    (setq-local compilation-messages-start (point))
+    (setq-local compilation-current-error nil)))
+
+;; This is for testing <command>\n as escape sequence to send
+;; commands to the Forth process.  Only implemented for Gforth so far.
+(defun forth-term-ping (string)
+  (interactive "sPing: ")
+  (cl-assert (not (string-match "\n" string)))
+  (term-send-string (forth-term--process) (concat "ping " string "\n")))
+
+(defun forth-term-include ()
+  "Load (i.e. INCLUDE) the file for the current buffer."
+  (interactive)
+  (save-some-buffers)
+  (forth-term--prepare-next-error-function)
+  (term-proc-query (forth-term--process)
+		   (format "s\" %s\" included\n" (buffer-file-name))))
+
+(defun forth-term-edit (name)
+  "Jump to the source code of NAME."
+  (interactive (list (read-from-minibuffer "Definition name: "
+					   (thing-at-point 'symbol))))
+  (term-proc-query (forth-term--process) (format "edit %s\n" name)))
+
+(defun forth-term-browse (pattern)
+  "List words matching PATTERN.
+You can use `next-error' to jump to the individual words in turn."
+  (interactive (list (read-from-minibuffer "Pattern: "
+					   (thing-at-point 'symbol))))
+  (forth-term--prepare-next-error-function)
+  (term-proc-query (forth-term--process) (format "browse %s\n" pattern)))
+
+(defun forth-term-where (name)
+  "List the locations where the word NAME is used.
+You can use `next-error' to jump to cycle through the listed
+locations."
+  (interactive (list (read-from-minibuffer "Definition name: "
+					   (thing-at-point 'symbol))))
+  (forth-term--prepare-next-error-function)
+  (term-proc-query (forth-term--process) (format "where %s\n" name)))
+
+(provide 'forth-term)


### PR DESCRIPTION
I think it could be useful to use term-mode instead  comint-mode, because term-mode supports cursor positioning. Some form cursor pisitioning is needed if we want to support things like Gforth's status line at the bottom of the window. And I have to admit, that Gforth's status line is kinda useful.  Another advantage of term-mode would be, that we get TAB-completion simply because Gforth already has some form of TAB-completion.

This branch adds a file `forth-term.el` that is basically a replacement for forth-interaction-mode. You can try it out with `M-x forth-term`.  The `*forth-term*` buffer should work like a normal xterm. The only advantage over running a Forth in a xterm is that we can pop up the `*forth-term*` window in response to commands like `forth-term-include`.

There are also very primitive commands that call Gforth's EDIT, BROWSE and WHERE commands from Forth source files. Those rely in some way on compilation-mode and emacsclient.  (I have some customizations for compilation-mode to work better with Gforth's error message, but those aren't included yet.)

In case you don't know: term-mode has two minor modes: _line-mode_ and _char-mode_.  The code switches to char-mode by default, but that can be confusing because `C-x` and almost all other keys are passed directly to the Forth process. Line-mode
works more like `comint-mode` or perhaps like `scrollback` mode in GNU screen.  It's imprtant to remember that `C-c C-j` and `C-c C-k` can be used to switch between those two modes.

The file `backend/gforth.fth` also contains some code that would allow us to send an escape sequence (`^Z<command>\n`) from Emacs to Forth that GForth interprets when it reads input via KEY. This is just an experiment; I don't know if it's worth it.  Using a seperate socket might be better if we really want to have some reliable communication channel.

So what do think about this?
